### PR TITLE
Port improvements to NrSketch

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
-nrSketchVersion=1.1
+nrSketchVersion=1.2
 jetBrainsAnnotationsVersion=13.0
-junitVersion=4.12
+junitVersion=4.13
 jmhVersion=1.26
 spotbugsAnnotationsVersion=4.4.1

--- a/src/main/java/com/newrelic/nrsketch/ComboNrSketch.java
+++ b/src/main/java/com/newrelic/nrsketch/ComboNrSketch.java
@@ -46,6 +46,9 @@ public class ComboNrSketch implements NrSketch {
     public ComboNrSketch(final int maxNumBucketsPerHistogram,
                          final int initialScale,
                          final Function<Integer, ScaledIndexer> indexerMaker) {
+        if (maxNumBucketsPerHistogram <= 0) {
+            throw new IllegalArgumentException("maxNumBucketsPerHistogram " + maxNumBucketsPerHistogram + " must be greater than 0");
+        }
         this.maxNumBucketsPerHistogram = maxNumBucketsPerHistogram;
         this.initialScale = initialScale;
         this.indexerMaker = indexerMaker;

--- a/src/main/java/com/newrelic/nrsketch/ComboNrSketch.java
+++ b/src/main/java/com/newrelic/nrsketch/ComboNrSketch.java
@@ -170,6 +170,19 @@ public class ComboNrSketch implements NrSketch {
         if (other.positiveHistogram != null) {
             getOrCreatePositveHistogram().subtract(other.positiveHistogram);
         }
+
+        return compact();
+    }
+
+    private NrSketch compact() {
+        if (negativeHistogram != null && negativeHistogram.getCount() == 0) {
+            negativeHistogram = null;
+            histograms.remove(0);
+        }
+        if (positiveHistogram != null && positiveHistogram.getCount() == 0) {
+            positiveHistogram = null;
+            histograms.remove(histograms.size() - 1);
+        }
         return this;
     }
 

--- a/src/main/java/com/newrelic/nrsketch/NrSketch.java
+++ b/src/main/java/com/newrelic/nrsketch/NrSketch.java
@@ -24,7 +24,19 @@ public interface NrSketch extends Iterable<NrSketch.Bucket> {
     // While merge() implements addition, subtract() implements subtraction.
     // Subtraction is useful to produce a delta histogram from accumulative histograms.
     // This function subtracts "other" from "this". Always returns "this".
-    // An implementation should not modify "other".
+    //
+    // Implementations should not modify "other".
+    //
+    // In cases where the source data was not recorded directly into an NrSketch instance,
+    // there will likely be some kind of translation logic involving floating point error
+    // when interpolating source buckets into NrSketch buckets that needs to be accounted for.
+    // That accounting may end up with valid cumulative source data getting translated into
+    // NrSketch buckets where some buckets appear to decrease by one. This happens because the
+    // place where the extra bucket count lands during translation may end up in a different
+    // bucket in a subsequent translation.
+    //
+    // Implementations should allow for this, and "borrow" the count from a neighboring bucket
+    // to keep the totalCount == sum(bucketCounts).
     NrSketch subtract(final NrSketch other);
 
     // Returns a deep copy of the sketch.

--- a/src/main/java/com/newrelic/nrsketch/SimpleNrSketch.java
+++ b/src/main/java/com/newrelic/nrsketch/SimpleNrSketch.java
@@ -61,6 +61,9 @@ public class SimpleNrSketch implements NrSketch {
                           final int initialScale,
                           final boolean bucketHoldsPositiveNumbers,
                           final Function<Integer, ScaledIndexer> indexerMaker) {
+        if (maxNumBuckets <= 0) {
+            throw new IllegalArgumentException("maxNumBuckets " + maxNumBuckets + " must be greater than 0");
+        }
         buckets = new WindowedCounterArray(maxNumBuckets);
         this.bucketHoldsPositiveNumbers = bucketHoldsPositiveNumbers;
         this.indexerMaker = indexerMaker;

--- a/src/main/java/com/newrelic/nrsketch/SimpleNrSketch.java
+++ b/src/main/java/com/newrelic/nrsketch/SimpleNrSketch.java
@@ -10,7 +10,9 @@ import com.newrelic.nrsketch.indexer.ScaledIndexer;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.jetbrains.annotations.NotNull;
 
+import java.util.ArrayList;
 import java.util.Iterator;
+import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.function.Function;
 
@@ -432,6 +434,7 @@ public class SimpleNrSketch implements NrSketch {
                 throw new IllegalArgumentException("SimpleNrSketch subtraction: merged scale must be equal or lower than a component");
             }
 
+            final List<Long> negativeCountIndices = new ArrayList<>();
             final int deltaB = b.getScale() - a.getScale();
 
             // Now subtract b buckets from a.
@@ -440,10 +443,21 @@ public class SimpleNrSketch implements NrSketch {
                 if (!a.buckets.increment(indexA, -b.buckets.get(indexB))) {
                     throw new RuntimeException("subtract(): failed to increment bucket");
                 }
-                if (a.buckets.get(indexA) < 0) {
-                    throw new IllegalArgumentException("SimpleNrSketch subtraction: negative bucket count not expected");
+                final long newCount = a.buckets.get(indexA);
+                if (newCount < -1) {
+                    throw new IllegalArgumentException("SimpleNrSketch subtraction: negative bucket count of " + newCount + " not expected. Count must be >= -1");
+                } else if (newCount == -1) {
+                    // When converting a histogram from one format to another, linear interpolation is often used to
+                    // split a bucket. The split produces non integer counts that need to be rounded to integers. When
+                    // doing subtraction in the native format of two histograms, we don't expect negative count in the
+                    // resulting buckets. But if we convert the input histograms, then do subtraction on the converted
+                    // histograms, some buckets can get -1 count, due to "rounding error" in the conversion. We will do
+                    // a round of correction to eliminate such negative count without changing the total count in the result.
+                    negativeCountIndices.add(indexA);
                 }
             }
+
+            balanceNegativeCounts(a, negativeCountIndices);
 
             a.shrinkBuckets();
         }
@@ -473,6 +487,35 @@ public class SimpleNrSketch implements NrSketch {
         a.sum -= b.sum;
 
         return a;
+    }
+
+    private static void balanceNegativeCounts(final SimpleNrSketch a, final List<Long> negativeCountIndices) {
+        negativeCountIndices.forEach(index -> {
+            a.buckets.increment(index, 1); // set negative bucket count to zero
+            a.buckets.increment(findNonEmptyBucketIndex(a, index), -1); // take that count from nearby bucket
+        });
+    }
+
+    private static long findNonEmptyBucketIndex(final SimpleNrSketch a, final long negativeCountIndex) {
+        long index = negativeCountIndex;
+        while (--index >= a.buckets.getIndexStart() && a.buckets.get(index) <= 0) {
+            // find the index of the first positive bucket count less than negativeCountIndex
+        }
+
+        if (index >= a.buckets.getIndexStart()) {
+            return index;
+        }
+
+        index = negativeCountIndex;
+        while (++index <= a.buckets.getIndexEnd() && a.buckets.get(index) <= 0) {
+            // find the index of the first positive bucket count greater than negativeCountIndex
+        }
+
+        if (index <= a.buckets.getIndexEnd()) {
+            return index;
+        }
+
+        throw new IllegalArgumentException("SimpleNrSketch subtraction: Cannot borrow from another bucket to compensate for a negative bucket count.");
     }
 
     // Shrink buckets start and end index to exclude zero count buckets.

--- a/src/main/java/com/newrelic/nrsketch/WindowedCounterArray.java
+++ b/src/main/java/com/newrelic/nrsketch/WindowedCounterArray.java
@@ -21,6 +21,9 @@ public class WindowedCounterArray {
     }
 
     public WindowedCounterArray(final int maxSize, final byte bytesPerCounter) {
+        if (maxSize <= 0) {
+            throw new IllegalArgumentException("maxSize " + maxSize + " must be greater than 0");
+        }
         backingArray = new MultiTypeCounterArray(maxSize, bytesPerCounter);
         this.maxSize = maxSize;
         indexBase = NULL_INDEX;

--- a/src/test/java/com/newrelic/nrsketch/ComboNrSketchTest.java
+++ b/src/test/java/com/newrelic/nrsketch/ComboNrSketchTest.java
@@ -33,6 +33,11 @@ import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
 
 public class ComboNrSketchTest {
+    @Test(expected = IllegalArgumentException.class)
+    public void testInitializedWithZeroMaxBucketCount() {
+        new ComboNrSketch(0);
+    }
+
     @Test
     public void testConstructors() {
         ComboNrSketch sketch = new ComboNrSketch();

--- a/src/test/java/com/newrelic/nrsketch/SimpleNrSketchTest.java
+++ b/src/test/java/com/newrelic/nrsketch/SimpleNrSketchTest.java
@@ -1356,9 +1356,9 @@ public class SimpleNrSketchTest {
         // simulate OTLP -> SimpleNrSketch translation error where some amount of count shuffling can occur due to linear interpolation
         cumulativeWithNegativeHistogram.insert(-1000, -1);
 
-        final NrSketch negativeDifference = cumulativeWithPositiveHistogram.deepCopy().subtract(positiveHistogram);
+        final NrSketch negativeDifference = cumulativeWithNegativeHistogram.deepCopy().subtract(negativeHistogram);
         // Total count difference is still the expected value, and the negative count is taken from another bucket
-        assertEquals(cumulativeWithPositiveHistogram.getCount() - positiveHistogram.getCount(), negativeDifference.getCount());
+        assertEquals(cumulativeWithNegativeHistogram.getCount() - negativeHistogram.getCount(), negativeDifference.getCount());
         final LongStream.Builder negativeCountStream = LongStream.builder();
         negativeDifference.forEach(b -> {
             assertTrue(b.count >= 0);
@@ -1399,9 +1399,9 @@ public class SimpleNrSketchTest {
         // simulate OTLP -> SimpleNrSketch translation error where some amount of count shuffling can occur due to linear interpolation
         cumulativeWithNegativeHistogram.insert(-1, -1);
 
-        final NrSketch negativeDifference = cumulativeWithPositiveHistogram.deepCopy().subtract(positiveHistogram);
+        final NrSketch negativeDifference = cumulativeWithNegativeHistogram.deepCopy().subtract(negativeHistogram);
         // Total count difference is still the expected value, and the negative count is taken from another bucket
-        assertEquals(cumulativeWithPositiveHistogram.getCount() - positiveHistogram.getCount(), negativeDifference.getCount());
+        assertEquals(cumulativeWithNegativeHistogram.getCount() - negativeHistogram.getCount(), negativeDifference.getCount());
         final LongStream.Builder negativeCountStream = LongStream.builder();
         negativeDifference.forEach(b -> {
             assertTrue(b.count >= 0);

--- a/src/test/java/com/newrelic/nrsketch/SimpleNrSketchTest.java
+++ b/src/test/java/com/newrelic/nrsketch/SimpleNrSketchTest.java
@@ -8,21 +8,20 @@ import com.newrelic.nrsketch.NrSketch.Bucket;
 import com.newrelic.nrsketch.indexer.DoubleFormat;
 import com.newrelic.nrsketch.indexer.IndexerOption;
 import com.newrelic.nrsketch.indexer.ScaledIndexer;
-import org.hamcrest.BaseMatcher;
 import org.junit.Test;
 
 import java.nio.ByteBuffer;
 import java.util.Iterator;
 import java.util.function.Function;
 import java.util.stream.LongStream;
-import java.util.stream.Stream;
 
 import static com.newrelic.nrsketch.ComboNrSketch.maxWithNan;
-import static com.newrelic.nrsketch.SimpleNrSketch.DEFAULT_INIT_SCALE;
 import static com.newrelic.nrsketch.indexer.BucketIndexerTest.assertDoubleEquals;
 import static com.newrelic.nrsketch.indexer.BucketIndexerTest.assertLongEquals;
-import static org.junit.Assert.*;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 
 public class SimpleNrSketchTest {
     public static final int TEST_MAX_BUCKETS = 320;
@@ -44,14 +43,14 @@ public class SimpleNrSketchTest {
     @Test
     public void testConstructors() {
         assertEquals(160, SimpleNrSketch.DEFAULT_MAX_BUCKETS);
-        assertEquals(20, DEFAULT_INIT_SCALE);
+        assertEquals(20, SimpleNrSketch.DEFAULT_INIT_SCALE);
         assertEquals(IndexerOption.AUTO_SELECT, SimpleNrSketch.DEFAULT_INDEXER_MAKER);
 
         SimpleNrSketch sketch = new SimpleNrSketch();
-        assertParams(sketch, SimpleNrSketch.DEFAULT_MAX_BUCKETS, DEFAULT_INIT_SCALE, true, SimpleNrSketch.DEFAULT_INDEXER_MAKER);
+        assertParams(sketch, SimpleNrSketch.DEFAULT_MAX_BUCKETS, SimpleNrSketch.DEFAULT_INIT_SCALE, true, SimpleNrSketch.DEFAULT_INDEXER_MAKER);
 
         sketch = new SimpleNrSketch(99);
-        assertParams(sketch, 99, DEFAULT_INIT_SCALE, true, SimpleNrSketch.DEFAULT_INDEXER_MAKER);
+        assertParams(sketch, 99, SimpleNrSketch.DEFAULT_INIT_SCALE, true, SimpleNrSketch.DEFAULT_INDEXER_MAKER);
 
         sketch = new SimpleNrSketch(99, 43);
         assertParams(sketch, 99, 43, true, SimpleNrSketch.DEFAULT_INDEXER_MAKER);
@@ -1349,7 +1348,7 @@ public class SimpleNrSketchTest {
 
         // Negative
 
-        final NrSketch negativeHistogram = SimpleNrSketch.newNegativeHistogram(100, DEFAULT_INIT_SCALE);
+        final NrSketch negativeHistogram = SimpleNrSketch.newNegativeHistogram(100, SimpleNrSketch.DEFAULT_INIT_SCALE);
         insertData(negativeHistogram, -1024, 0, 4096);
         final NrSketch cumulativeWithNegativeHistogram = negativeHistogram.deepCopy();
         insertData(cumulativeWithNegativeHistogram, -512, 0, 512);
@@ -1392,7 +1391,7 @@ public class SimpleNrSketchTest {
 
         // Negative
 
-        final NrSketch negativeHistogram = SimpleNrSketch.newNegativeHistogram(100, DEFAULT_INIT_SCALE);
+        final NrSketch negativeHistogram = SimpleNrSketch.newNegativeHistogram(100, SimpleNrSketch.DEFAULT_INIT_SCALE);
         insertData(negativeHistogram, -1024, 0, 4096);
         final NrSketch cumulativeWithNegativeHistogram = negativeHistogram.deepCopy();
         insertData(cumulativeWithNegativeHistogram, -1024, -512, 512);
@@ -1426,9 +1425,9 @@ public class SimpleNrSketchTest {
 
         // Negative
 
-        final NrSketch negativeHistogram = SimpleNrSketch.newNegativeHistogram(10, DEFAULT_INIT_SCALE);
+        final NrSketch negativeHistogram = SimpleNrSketch.newNegativeHistogram(10, SimpleNrSketch.DEFAULT_INIT_SCALE);
         negativeHistogram.insert(-1);
-        final NrSketch negativeHistogram2 = SimpleNrSketch.newNegativeHistogram(10, DEFAULT_INIT_SCALE);
+        final NrSketch negativeHistogram2 = SimpleNrSketch.newNegativeHistogram(10, SimpleNrSketch.DEFAULT_INIT_SCALE);
 
         assertEquals(
                 "SimpleNrSketch subtraction: Cannot borrow from another bucket to compensate for a negative bucket count.",
@@ -1455,7 +1454,7 @@ public class SimpleNrSketchTest {
 
         // Negative
 
-        final NrSketch negativeHistogram = SimpleNrSketch.newNegativeHistogram(100, DEFAULT_INIT_SCALE);
+        final NrSketch negativeHistogram = SimpleNrSketch.newNegativeHistogram(100, SimpleNrSketch.DEFAULT_INIT_SCALE);
         insertData(negativeHistogram, -1024, 0, 4096);
         final NrSketch cumulativeWithNegativeHistogram = negativeHistogram.deepCopy();
         insertData(cumulativeWithNegativeHistogram, -512, 0, 512);

--- a/src/test/java/com/newrelic/nrsketch/SimpleNrSketchTest.java
+++ b/src/test/java/com/newrelic/nrsketch/SimpleNrSketchTest.java
@@ -33,6 +33,11 @@ public class SimpleNrSketchTest {
     public static final double SCALE3_ERROR = 0.04329461749938920;
     public static final double SCALE4_ERROR = 0.02165746232622625;
 
+    @Test(expected = IllegalArgumentException.class)
+    public void testInitializedWithZeroMaxBucketCount() {
+        new SimpleNrSketch(0);
+    }
+
     @Test
     public void testConstructors() {
         assertEquals(160, SimpleNrSketch.DEFAULT_MAX_BUCKETS);

--- a/src/test/java/com/newrelic/nrsketch/WindowedCounterArrayTest.java
+++ b/src/test/java/com/newrelic/nrsketch/WindowedCounterArrayTest.java
@@ -14,6 +14,11 @@ import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
 
 public class WindowedCounterArrayTest {
+    @Test(expected = IllegalArgumentException.class)
+    public void testInitializedWithZeroMaxBucketCount() {
+        new WindowedCounterArray(0);
+    }
+
     @Test
     public void happyPath() {
         final WindowedCounterArray array = new WindowedCounterArray(10);


### PR DESCRIPTION
Each commit in this PR brings in an enhancement or bug fix that have been added to internal code bases. 

a231ef5bfc34d070565393b24b8d540ca81f65da: When a subtraction between two histograms ends up with an empty positive and/or negative sub histogram on the ComboNrSketch, serialization space can be saved by `null`ing out that empty histogram.

09da56973c3d05e932b9b57820ecc62ba9c7aaa7: This disallows `0` to be used when constructing any existing NrSketch implementation, as well as the internal structures that they utilize. The implementation of SimpleNrSketch has an infinite loop whenever something like this occurs:

```java
new SimpleNrSketch(0).merge(someNonEmptySimpleNrSketch)
```

23cb4e6dc718b9f6160d03b5832f5d7c9d78c0fd: In cases where the source measurements for the histogram are not recorded directly in an NrSketch (or equivalent exponential format like OTLP) then chances are that some mapping occurred to transform the original histogram format to the NrSketch format. Due to the rounding errors that occur when interpolating source buckets into NrSketch buckets, there will inevitably be some "surplus" count that needs to be accounted for and added to some bucket. With cumulative histograms, the `subtract()` function is a useful way of recovering the delta. However, the bucket this "surplus" ends up in may change in subsequent cumulative histograms due to the rounding error changing with the larger counts. As such, `subtract()` may legitimately end up with a `-1` as a result in one or more buckets of legitimate cumulative source data. This commit allows for such a situation and "borrows" the missing count from a nearby bucket to keep the bucket counts and total count the same.